### PR TITLE
Implement diagnostic flow for mantra bot

### DIFF
--- a/telegram-mantra-bot/bot/handlers/selection.py
+++ b/telegram-mantra-bot/bot/handlers/selection.py
@@ -1,6 +1,12 @@
 from aiogram import Router, types
 from aiogram.filters import CallbackQuery
-from ..keyboards import request_keyboard
+from ..keyboards import (
+    request_keyboard,
+    diag_start_keyboard,
+    negative_options_keyboard,
+    neutral_options_keyboard,
+    positive_options_keyboard,
+)
 
 router = Router()
 
@@ -13,5 +19,87 @@ async def has_request(query: types.CallbackQuery) -> None:
 
 @router.callback_query(CallbackQuery(data='explore_inside'))
 async def explore(query: types.CallbackQuery) -> None:
-    await query.message.answer('Сначала самодиагностика. Готовы пройти?', reply_markup=types.InlineKeyboardMarkup(inline_keyboard=[[types.InlineKeyboardButton(text='\U0001F9ED Пройти самодиагностику', callback_data='start_diag')]]))
+    await query.message.answer(
+        'Сначала самодиагностика. Готовы пройти?',
+        reply_markup=types.InlineKeyboardMarkup(
+            inline_keyboard=[[
+                types.InlineKeyboardButton(
+                    text='\U0001F9ED Пройти самодиагностику',
+                    callback_data='start_diag'
+                )
+            ]]
+        )
+    )
     await query.answer()
+
+
+@router.callback_query(CallbackQuery(data='start_diag'))
+async def diag_start(query: types.CallbackQuery) -> None:
+    await query.message.answer(
+        'Что ты чаще всего ощущаешь в последнее время — внутри себя, в фоне?',
+        reply_markup=diag_start_keyboard()
+    )
+    await query.answer()
+
+
+@router.callback_query(CallbackQuery(data='diag_negative'))
+async def diag_negative(query: types.CallbackQuery, state: dict) -> None:
+    state['diag_type'] = 'negative'
+    await query.message.answer(
+        'Выберите более точное состояние:',
+        reply_markup=negative_options_keyboard()
+    )
+    await query.answer()
+
+
+@router.callback_query(CallbackQuery(data='diag_neutral'))
+async def diag_neutral(query: types.CallbackQuery, state: dict) -> None:
+    state['diag_type'] = 'neutral'
+    await query.message.answer(
+        'Выберите более точное состояние:',
+        reply_markup=neutral_options_keyboard()
+    )
+    await query.answer()
+
+
+@router.callback_query(CallbackQuery(data='diag_positive'))
+async def diag_positive(query: types.CallbackQuery, state: dict) -> None:
+    state['diag_type'] = 'positive'
+    await query.message.answer(
+        'Выберите более точное состояние:',
+        reply_markup=positive_options_keyboard()
+    )
+    await query.answer()
+
+
+OPTION_BLOCKS = {
+    'opt_emotions_trouble': 'ЭМОЦИИ',
+    'opt_selfcrit': 'САМООЦЕНКА',
+    'opt_procrastination': 'ПОВЕДЕНИЕ',
+    'opt_loneliness': 'ОТНОШЕНИЯ',
+    'opt_apathy': 'СМЫСЛ',
+    'opt_anger': 'ЭМОЦИИ',
+    'opt_guilt': 'САМООЦЕНКА',
+    'opt_unrest': 'ЭМОЦИИ',
+    'opt_nofeel': 'ПОВЕДЕНИЕ',
+    'opt_auto': 'ПОВЕДЕНИЕ',
+    'opt_stuck': 'ПОВЕДЕНИЕ',
+    'opt_unknown': 'САМООЦЕНКА',
+    'opt_detached': 'СМЫСЛ',
+    'opt_empty': 'СМЫСЛ',
+    'opt_self': 'СМЫСЛ',
+    'opt_beliefs': 'САМООЦЕНКА',
+    'opt_changes': 'ЭМОЦИИ',
+    'opt_observe': 'ПОВЕДЕНИЕ',
+    'opt_dialog': 'ОТНОШЕНИЯ',
+    'opt_support': 'СМЫСЛ',
+    'opt_bias': 'ПОВЕДЕНИЕ',
+}
+
+
+@router.callback_query(CallbackQuery(lambda c: c.data in OPTION_BLOCKS))
+async def diag_option(query: types.CallbackQuery, state: dict) -> None:
+    state['diag_block'] = OPTION_BLOCKS[query.data]
+    # Start socratic questions
+    from .socratic import begin_questions
+    await begin_questions(query, state)

--- a/telegram-mantra-bot/bot/handlers/socratic.py
+++ b/telegram-mantra-bot/bot/handlers/socratic.py
@@ -13,8 +13,8 @@ QUESTIONS = [
 ]
 
 
-@router.callback_query(CallbackQuery(data='start_diag'))
-async def start_diag(query: types.CallbackQuery, state: dict) -> None:
+@router.callback_query(CallbackQuery(data='begin_questions'))
+async def begin_questions(query: types.CallbackQuery, state: dict) -> None:
     state['topic'] = Topic(user_id=await User.id_by_telegram(query.from_user.id), title='Новая тема')
     session = SessionLocal()
     session.add(state['topic'])

--- a/telegram-mantra-bot/bot/keyboards.py
+++ b/telegram-mantra-bot/bot/keyboards.py
@@ -23,3 +23,51 @@ def request_keyboard() -> types.InlineKeyboardMarkup:
         ]
     ]
     return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def diag_start_keyboard() -> types.InlineKeyboardMarkup:
+    keyboard = [
+        [types.InlineKeyboardButton(text='\U0001F641 Негативное', callback_data='diag_negative')],
+        [types.InlineKeyboardButton(text='\U0001F610 Нейтральное', callback_data='diag_neutral')],
+        [types.InlineKeyboardButton(text='\U0001F9D8 Позитивное', callback_data='diag_positive')]
+    ]
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def negative_options_keyboard() -> types.InlineKeyboardMarkup:
+    keyboard = [
+        [types.InlineKeyboardButton(text='\U0001F61F Тревожность, страх', callback_data='opt_emotions_trouble')],
+        [types.InlineKeyboardButton(text='\U0001F61E Самокритика, «я не такой»', callback_data='opt_selfcrit')],
+        [types.InlineKeyboardButton(text='\U0001F501 Прокрастинация, застревание', callback_data='opt_procrastination')],
+        [types.InlineKeyboardButton(text='\U0001F494 Ощущение одиночества', callback_data='opt_loneliness')],
+        [types.InlineKeyboardButton(text='\U0001F610 Апатия, пустота', callback_data='opt_apathy')],
+        [types.InlineKeyboardButton(text='\U0001F620 Раздражение, гнев', callback_data='opt_anger')],
+        [types.InlineKeyboardButton(text='\U0001F630 Стыд, вина', callback_data='opt_guilt')]
+    ]
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def neutral_options_keyboard() -> types.InlineKeyboardMarkup:
+    keyboard = [
+        [types.InlineKeyboardButton(text='\U0001F301 Непонятное напряжение', callback_data='opt_unrest')],
+        [types.InlineKeyboardButton(text='\U0001F636 «Ничего не чувствую»', callback_data='opt_nofeel')],
+        [types.InlineKeyboardButton(text='\u23F3 Автоматизм, инерция', callback_data='opt_auto')],
+        [types.InlineKeyboardButton(text='\U0001F914 Понять, в чём застрял', callback_data='opt_stuck')],
+        [types.InlineKeyboardButton(text='\U0001F62C Что-то не так, но что?', callback_data='opt_unknown')],
+        [types.InlineKeyboardButton(text='\U0001F9CD Живу рядом с собой', callback_data='opt_detached')],
+        [types.InlineKeyboardButton(text='\U0001F937 «Вроде всё норм, но пусто»', callback_data='opt_empty')]
+    ]
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def positive_options_keyboard() -> types.InlineKeyboardMarkup:
+    keyboard = [
+        [types.InlineKeyboardButton(text='\u2728 Хочу глубже понять себя', callback_data='opt_self')],
+        [types.InlineKeyboardButton(text='\U0001F4A1 Пора пересмотреть установки', callback_data='opt_beliefs')],
+        [types.InlineKeyboardButton(text='\U0001F331 В процессе перемен', callback_data='opt_changes')],
+        [types.InlineKeyboardButton(text='\U0001F50D Наблюдаю за собой', callback_data='opt_observe')],
+        [types.InlineKeyboardButton(text='\U0001F4AC Переформулировать диалог', callback_data='opt_dialog')],
+        [types.InlineKeyboardButton(text='\U0001F9D8 Больше внутренней опоры', callback_data='opt_support')],
+        [types.InlineKeyboardButton(text='\U0001F3AF Когнитивные ловушки', callback_data='opt_bias')]
+    ]
+    return types.InlineKeyboardMarkup(inline_keyboard=keyboard)


### PR DESCRIPTION
## Summary
- add detailed diagnostics keyboards
- implement callback handlers for new diagnostic flow
- rename question starting handler to `begin_questions`

## Testing
- `python -m py_compile telegram-mantra-bot/bot/**/*.py telegram-mantra-bot/models.py`